### PR TITLE
fix blobs style.wrapper's conditional styling

### DIFF
--- a/src/BlobField/index.js
+++ b/src/BlobField/index.js
@@ -6,7 +6,7 @@ import paper from "paper";
 import style from "./style.module.scss";
 import Blobs from "./blobs";
 
-import ArtistNav from '../Components/ArtistNav/';
+import ArtistNav from "../Components/ArtistNav/";
 
 export default function BlobField({ collapsed = false }) {
   const animationEl = useRef(null);
@@ -70,15 +70,14 @@ export default function BlobField({ collapsed = false }) {
     blobsRef.current && blobsRef.current.setIsCollapsed(collapsed);
   }, [blobsRef, collapsed]);
 
-
   return (
-    <div className={style.wrapper} ref={wrapperEl} style={{width: parentWidth, height: parentHeight}}>
+    <div
+      className={style.wrapper}
+      ref={wrapperEl}
+      style={collapsed ? {} : { width: parentWidth, height: parentHeight }}
+    >
       <ArtistNav />
-      <canvas
-        ref={animationEl}
-        width={width}
-        height={height}
-      />
+      <canvas ref={animationEl} width={width} height={height} />
       {collapsed ? (
         ""
       ) : (


### PR DESCRIPTION
Adds to blobs' `style.wrapper` conditional width/height to fix and remove the extra bottom margin  on collapsed pages.

Scroll to the bottom and compare the empty space of [master](https://kind-tesla-a088c1.netlify.app/graham-akins) with [this pr](http://deploy-preview-35--kind-tesla-a088c1.netlify.app/graham-akins)

The reason why I'm adding the `{ width: parentWidth, height: parentHeight }` is to resolve vertical title centering on homepage without resorting to setting App's `min-height:100vh` which is not mobile friendly at all. 

This commit ensures that `{ width: parentWidth, height: parentHeight }` is only set when the blobs are _not_ collapsed, which right now only happens on homepage. On other pages styling is removed, and `height` is subsequently set to 0, but since blobs are `absolute` this does not change behavior. 

https://github.com/blerchin/dma-20-mfa-show/blob/bf5364b393ed9301cd5827df04832ee70f42f7e8/src/BlobField/index.js#L74-L78