### PR TITLE
Collapsed names

### DIFF
--- a/src/BlobField/ball.js
+++ b/src/BlobField/ball.js
@@ -41,7 +41,7 @@ export default class Ball {
 			closed: true,
 			shadowColor: this.shadowInactiveColor,
 			shadowBlur: 5,
-			shadowOffset: new paper.Point(-5, -5),
+			shadowOffset: new paper.Point(5, 5),
 		});
 
 		for (let i = 0; i < this.numSegment; i++) {

--- a/src/BlobField/index.js
+++ b/src/BlobField/index.js
@@ -23,6 +23,7 @@ export default function BlobField({ collapsed = false }) {
     const onArtistHovered = (event) => {
       if (event.type === "mouseenter") setActiveArtist(event.target.artist);
       else setActiveArtist(null);
+      console.log(event.target.position);
     };
 
     const onArtistClicked = (event) => {
@@ -82,7 +83,11 @@ export default function BlobField({ collapsed = false }) {
         ""
       ) : (
         <div className="title">
-          {activeArtist ? activeArtist.name.toUpperCase() : "NEARREST NEIGHBOR"}
+          {activeArtist
+            ? activeArtist.name.split(" ").map((item, i) => {
+                return <p key={i}>{item.toUpperCase()}</p>;
+              })
+            : "NEARREST NEIGHBOR"}
         </div>
       )}
     </div>

--- a/src/BlobField/index.js
+++ b/src/BlobField/index.js
@@ -14,16 +14,52 @@ export default function BlobField({ collapsed = false }) {
   const blobsRef = useRef(null);
   const history = useHistory();
   const [activeArtist, setActiveArtist] = useState(null);
+  const [blobEvent, setBlobEvent] = useState(null);
   const [height, setHeight] = useState(window.innerHeight);
   const [width, setWidth] = useState(window.innerWidth);
   const [parentWidth, setParentWidth] = useState(window.innerWidth);
   const [parentHeight, setParentHeight] = useState(window.innerHeight);
+  const popoverStyle = usePopooverStyle(blobEvent);
+
+  function usePopooverStyle(event) {
+    let style = {
+      display: 'none'
+    };
+    
+    if (collapsed && event && event.type === "mouseenter") {
+      const isVertical = window.innerWidth > window.innerHeight
+      const count = config.artists.length;
+      const totalLength = isVertical ? window.innerHeight : document.body.clientWidth;
+      const canvasLength = totalLength / count;
+
+      let pos = event.target.position;
+      if (isVertical && pos.x < canvasLength){
+        style = {
+          top: pos.y,
+          right: canvasLength + 5,
+          transform: 'translate(0, -50%)'
+        };
+      }
+      else if (!isVertical && pos.y < canvasLength){
+        style = {
+          bottom: canvasLength + 5,
+          left: '50%',
+          transform: 'translate(-50%, 0)'
+        };
+      }
+    }
+    return style;
+  }
 
   useEffect(() => {
     const onArtistHovered = (event) => {
-      if (event.type === "mouseenter") setActiveArtist(event.target.artist);
-      else setActiveArtist(null);
-      console.log(event.target.position);
+      if (event.type === "mouseenter") {
+        setActiveArtist(event.target.artist);
+        setBlobEvent(event);
+      } else {
+        setActiveArtist(null);
+        setBlobEvent(event);
+      }
     };
 
     const onArtistClicked = (event) => {
@@ -90,6 +126,9 @@ export default function BlobField({ collapsed = false }) {
             : "NEARREST NEIGHBOR"}
         </div>
       )}
+      <div className={style.popover} style={popoverStyle}>
+        {collapsed && activeArtist ? activeArtist.name.toUpperCase() : ""}
+      </div>
     </div>
   );
 }

--- a/src/BlobField/index.js
+++ b/src/BlobField/index.js
@@ -121,7 +121,7 @@ export default function BlobField({ collapsed = false }) {
         <div className="title">
           {activeArtist
             ? activeArtist.name.split(" ").map((item, i) => {
-                return <p key={i}>{item.toUpperCase()}</p>;
+                return <p key={item}>{item.toUpperCase()}</p>;
               })
             : "NEARREST NEIGHBOR"}
         </div>

--- a/src/BlobField/index.js
+++ b/src/BlobField/index.js
@@ -14,37 +14,37 @@ export default function BlobField({ collapsed = false }) {
   const blobsRef = useRef(null);
   const history = useHistory();
   const [activeArtist, setActiveArtist] = useState(null);
-  const [blobEvent, setBlobEvent] = useState(null);
   const [height, setHeight] = useState(window.innerHeight);
   const [width, setWidth] = useState(window.innerWidth);
   const [parentWidth, setParentWidth] = useState(window.innerWidth);
   const [parentHeight, setParentHeight] = useState(window.innerHeight);
-  const popoverStyle = usePopooverStyle(blobEvent);
+  const [popoverStyle, setPopooverStyle] = useState(null);
 
-  function usePopooverStyle(event) {
+  function calculateStyle(event) {
     let style = {
-      display: 'none'
+      display: "none",
     };
-    
+
     if (collapsed && event && event.type === "mouseenter") {
-      const isVertical = window.innerWidth > window.innerHeight
+      const isVertical = window.innerWidth > window.innerHeight;
       const count = config.artists.length;
-      const totalLength = isVertical ? window.innerHeight : document.body.clientWidth;
+      const totalLength = isVertical
+        ? window.innerHeight
+        : document.body.clientWidth;
       const canvasLength = totalLength / count;
 
       let pos = event.target.position;
-      if (isVertical && pos.x < canvasLength){
+      if (isVertical && pos.x < canvasLength) {
         style = {
           top: pos.y,
           right: canvasLength + 5,
-          transform: 'translate(0, -50%)'
+          transform: "translate(0, -50%)",
         };
-      }
-      else if (!isVertical && pos.y < canvasLength){
+      } else if (!isVertical && pos.y < canvasLength) {
         style = {
           bottom: canvasLength + 5,
-          left: '50%',
-          transform: 'translate(-50%, 0)'
+          left: "50%",
+          transform: "translate(-50%, 0)",
         };
       }
     }
@@ -55,11 +55,10 @@ export default function BlobField({ collapsed = false }) {
     const onArtistHovered = (event) => {
       if (event.type === "mouseenter") {
         setActiveArtist(event.target.artist);
-        setBlobEvent(event);
       } else {
         setActiveArtist(null);
-        setBlobEvent(event);
       }
+      setPopooverStyle(calculateStyle(event));
     };
 
     const onArtistClicked = (event) => {

--- a/src/BlobField/style.module.scss
+++ b/src/BlobField/style.module.scss
@@ -15,3 +15,13 @@
     }
 
 }
+
+.popover{
+    position: fixed;
+    z-index: 9999;
+    transform: translate(0, -50%);
+    padding: 5px;
+    font-family: var(--header-font);
+    font-weight: bold;
+    text-shadow: 0px 0px 10px #000000;
+}

--- a/src/BlobField/style.module.scss
+++ b/src/BlobField/style.module.scss
@@ -23,5 +23,5 @@
     padding: 5px;
     font-family: var(--header-font);
     font-weight: bold;
-    text-shadow: 0px 0px 10px #000000;
+    text-shadow: 0px 0px 20px rgba(0,0,0,0.25);;
 }


### PR DESCRIPTION
Adds the artist names next to blobs for readability. When in landscape orientation (blobs in a column) names appear adjacent to their blobs mimicking their `y` positioning. When in portrait mode (blobs in a row) names appear on the middle of the screen, immediately above the blobs.

The later decision was for readability, particularly for blobs near the window border. Same reasoning for the `text-shadow` as it was hard to read over bright backgrounds.

### Landscape:
![Screenshot_20200519_160813](https://user-images.githubusercontent.com/11205091/82387586-46f4c780-99ec-11ea-999a-8d16875e51db.png)
### Portraint:
![Screenshot_20200519_160751](https://user-images.githubusercontent.com/11205091/82387583-44926d80-99ec-11ea-864f-c4599d68430d.png)

## Modifies:
- #### src/BlobField/style.module.scss
  - https://github.com/blerchin/dma-20-mfa-show/blob/2c86fe5d2292da9fca1d37db43444771727581f9/src/BlobField/style.module.scss#L19-L27
- #### dma-20-mfa-show/src/BlobField/index.js
  - Using a custom hook to adjust the `popoverStyle` state which is assigned to
    `<div className={style.popover} style={popoverStyle}>`  https://github.com/blerchin/dma-20-mfa-show/blob/2c86fe5d2292da9fca1d37db43444771727581f9/src/BlobField/index.js#L22-L52
  - https://github.com/blerchin/dma-20-mfa-show/blob/2c86fe5d2292da9fca1d37db43444771727581f9/src/BlobField/index.js#L129-L132

- #### Artist names on two lines
  I also modified the code below, so that people with short names still have their first and last name show up on separate lines. (Leming & myself)
  - https://github.com/blerchin/dma-20-mfa-show/blob/2c86fe5d2292da9fca1d37db43444771727581f9/src/BlobField/index.js#L121-L127
