### PR TITLE
Fix issue with labels for collapsed blobs

### DIFF
--- a/src/BlobField/blobs.js
+++ b/src/BlobField/blobs.js
@@ -3,11 +3,7 @@ import paper from "paper";
 import Ball from "./ball";
 
 export default class Blobs {
-	constructor(artists, {
-		onArtistHovered,
-		onArtistClicked
-	}) {
-		console.log("Blobs#constructor");
+	constructor(artists) {
 		this.artists = artists;
 		this.balls = [];
 		this.numBalls = artists.length;
@@ -29,8 +25,6 @@ export default class Blobs {
 		this.collapsed = false;
 		this.targetWidth = null;
 		this.targetHeight = null;
-		this.onArtistHovered = onArtistHovered;
-		this.onArtistClicked = onArtistClicked;
 	}
 
 	B(idx) {
@@ -40,6 +34,14 @@ export default class Blobs {
 	setIsCollapsed(val) {
 		this.collapsed = val;
 		this.recalcCanvasSize();
+	}
+
+	setOnArtistHovered(cb) {
+		this.onArtistHovered = cb;
+	}
+
+	setOnArtistClicked(cb) {
+		this.onArtistClicked = cb;
 	}
 
 	calcCollapsedRadius() {

--- a/src/BlobField/blobs.js
+++ b/src/BlobField/blobs.js
@@ -114,8 +114,7 @@ export default class Blobs {
 			this.balls.push(currBall);
 		}
 
-		if (this.collapsed)
-			this.recalcCanvasSize()
+		this.recalcCanvasSize();
 	}
 
 	onFrame() {
@@ -161,7 +160,7 @@ export default class Blobs {
 		}
 	}
 
-	recalcCanvasSize() {
+	recalcCanvasSize() {		
 		let currWidth = document.body.clientWidth;
 		let currHeight = window.innerHeight;
 		if (this.collapsed) {

--- a/src/BlobField/index.js
+++ b/src/BlobField/index.js
@@ -14,18 +14,16 @@ export default function BlobField({ collapsed = false }) {
   const blobsRef = useRef(null);
   const history = useHistory();
   const [activeArtist, setActiveArtist] = useState(null);
-  const [height, setHeight] = useState(window.innerHeight);
-  const [width, setWidth] = useState(window.innerWidth);
   const [parentWidth, setParentWidth] = useState(window.innerWidth);
   const [parentHeight, setParentHeight] = useState(window.innerHeight);
   const [popoverStyle, setPopooverStyle] = useState(null);
 
-  function calculateStyle(event) {
+  function calculateStyle(event, isCollapsed) {
     let style = {
       display: "none",
     };
 
-    if (collapsed && event && event.type === "mouseenter") {
+    if (isCollapsed && event && event.type === "mouseenter") {
       const isVertical = window.innerWidth > window.innerHeight;
       const count = config.artists.length;
       const totalLength = isVertical
@@ -52,24 +50,12 @@ export default function BlobField({ collapsed = false }) {
   }
 
   useEffect(() => {
-    const onArtistHovered = (event) => {
-      if (event.type === "mouseenter") {
-        setActiveArtist(event.target.artist);
-      } else {
-        setActiveArtist(null);
-      }
-      setPopooverStyle(calculateStyle(event));
-    };
-
     const onArtistClicked = (event) => {
       history.push(`/${event.target.artist.slug}`);
     };
 
-    const blobs = (blobsRef.current = new Blobs(config.artists, {
-      onArtistHovered,
-      onArtistClicked,
-    }));
-
+    const blobs = blobsRef.current = new Blobs(config.artists);
+    blobs.setOnArtistClicked(onArtistClicked);
     blobs.collapsed = collapsed;
 
     const wrapper = wrapperEl.current;
@@ -103,7 +89,18 @@ export default function BlobField({ collapsed = false }) {
   }, [blobsRef]);
 
   useEffect(() => {
-    blobsRef.current && blobsRef.current.setIsCollapsed(collapsed);
+    if (blobsRef.current) {
+      const blobs = blobsRef.current;
+      blobs.setIsCollapsed(collapsed);
+      blobs.setOnArtistHovered((event) => {
+        if (event.type === "mouseenter") {
+          setActiveArtist(event.target.artist);
+        } else {
+          setActiveArtist(null);
+        }
+        setPopooverStyle(calculateStyle(event, collapsed));
+      });
+    }
   }, [blobsRef, collapsed]);
 
   return (
@@ -113,7 +110,7 @@ export default function BlobField({ collapsed = false }) {
       style={collapsed ? {} : { width: parentWidth, height: parentHeight }}
     >
       <ArtistNav />
-      <canvas ref={animationEl} width={width} height={height} />
+      <canvas ref={animationEl} width={window.innerWidth} height={window.innerHeight} />
       {collapsed ? (
         ""
       ) : (

--- a/src/BlobField/index.js
+++ b/src/BlobField/index.js
@@ -13,6 +13,8 @@ export default function BlobField({ collapsed = false }) {
   const wrapperEl = useRef(null);
   const blobsRef = useRef(null);
   const history = useHistory();
+  const [height, setHeight] = useState(window.innerHeight);
+  const [width, setWidth] = useState(window.innerWidth);
   const [activeArtist, setActiveArtist] = useState(null);
   const [parentWidth, setParentWidth] = useState(window.innerWidth);
   const [parentHeight, setParentHeight] = useState(window.innerHeight);
@@ -110,7 +112,7 @@ export default function BlobField({ collapsed = false }) {
       style={collapsed ? {} : { width: parentWidth, height: parentHeight }}
     >
       <ArtistNav />
-      <canvas ref={animationEl} width={window.innerWidth} height={window.innerHeight} />
+      <canvas ref={animationEl} width={width} height={height} />
       {collapsed ? (
         ""
       ) : (

--- a/src/BlobField/index.js
+++ b/src/BlobField/index.js
@@ -13,8 +13,6 @@ export default function BlobField({ collapsed = false }) {
   const wrapperEl = useRef(null);
   const blobsRef = useRef(null);
   const history = useHistory();
-  const [height, setHeight] = useState(window.innerHeight);
-  const [width, setWidth] = useState(window.innerWidth);
   const [activeArtist, setActiveArtist] = useState(null);
   const [parentWidth, setParentWidth] = useState(window.innerWidth);
   const [parentHeight, setParentHeight] = useState(window.innerHeight);
@@ -112,7 +110,7 @@ export default function BlobField({ collapsed = false }) {
       style={collapsed ? {} : { width: parentWidth, height: parentHeight }}
     >
       <ArtistNav />
-      <canvas ref={animationEl} width={width} height={height} />
+      <canvas ref={animationEl}/>
       {collapsed ? (
         ""
       ) : (


### PR DESCRIPTION
Addresses #39: labels do not always appear when collapsed blobs are hovered

Labels were not appearing in the collapsed state if a client-side route change had caused the value of `collapsed` in `BlobField` to change since initialization. This is because the `calculateStyle` function was closing on the original value and was never redefined.

Solution:
* add `isCollapsed` as an argument to `calculateStyle`
* update `Blobs` API to accept updates to callbacks after initialization
* replace the `onArtistHovered` callback with one that closes on the proper `collapsed` value whenever it changes, using `useEffect`