### PR TITLE
remove css title translate, set parentW/H on mount

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -25,10 +25,6 @@
       work correctly both with client-side routing and a non-root public URL.
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
-    <meta
-      name="description"
-      content="Online MFA show for 2020 DMA grads."
-    />
     <link rel="stylesheet" href="https://use.typekit.net/qmg6jpo.css">
     <title>NEARREST NEIGHBOR</title>
   </head>

--- a/src/BlobField/index.js
+++ b/src/BlobField/index.js
@@ -18,8 +18,8 @@ export default function BlobField() {
   const blobsRef = useRef(null);
   const history = useHistory();
   const [activeArtist, setActiveArtist] = useState(null);
-  const [parentWidth, setParentWidth] = useState(window.innerWidth);
-  const [parentHeight, setParentHeight] = useState(window.innerHeight);
+  const [parentWidth, setParentWidth] = useState('100vw');
+  const [parentHeight, setParentHeight] = useState('100vh');
   const [popoverStyle, setPopooverStyle] = useState(null);
 
   let location = useLocation();
@@ -96,6 +96,9 @@ export default function BlobField() {
   }, [blobsRef]);
 
   useEffect(() => {
+    setParentWidth(document.body.clientWidth);
+    setParentHeight(window.innerHeight);
+
     if (blobsRef.current) {
       const blobs = blobsRef.current;
       blobs.setIsCollapsed(collapsed);
@@ -115,7 +118,7 @@ export default function BlobField() {
       <div
         className={wrapper}
         ref={wrapperEl}
-        // style={collapsed ? {} : { width: parentWidth, height: parentHeight }}
+        style={collapsed ? {} : { width: parentWidth, height: parentHeight }}
       >
         <ArtistNav />
         <canvas ref={animationEl}/>

--- a/src/Components/Seo/index.js
+++ b/src/Components/Seo/index.js
@@ -96,7 +96,7 @@ const Seo = ({
       title: title ? `${title} | NEARREST NEIGHBOR` : "NEARREST NEIGHBOR",
       description: description
         ? description
-        : "Online MFA show for 2020 DMA grads.",
+        : "Online exhibition featuring thesis work from the 2020 graduating MFA class of the UCLA Design Media Arts department. Works span the genres of interactive installation, performance, sculpture, software, sound, print and video.",
       contentType,
       url: path ? absoluteUrl(path) : rootURL,
       published,

--- a/src/Containers/App/style.css
+++ b/src/Containers/App/style.css
@@ -33,8 +33,6 @@ body {
   font-family: sans-serif;
   font-weight: 700;
   line-height: initial;
-  margin-top: 50vh;
-  transform: translateY(-50%);
 }
 
 .blobs {


### PR DESCRIPTION
This is almost stupid. But I had to make some adjustment to get 1-1 styling with the dev build. 
Turns out the css translation and top margin were giving weird layouts on 2560x1440 res. 
I reverted to using js/react to set the style and made sure this happens at least once when the user loads the page and not only on resize. So it should be good now. 