### PR TITLE
Change url in readme to match netlify branch deploy

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-https://master--kind-tesla-a088c1.netlify.app/
+https://preview.near.rest
 
 This project was bootstrapped with [Create React App](https://github.com/facebook/create-react-app).
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-https://kind-tesla-a088c1.netlify.app/
+https://master--kind-tesla-a088c1.netlify.app/
 
 This project was bootstrapped with [Create React App](https://github.com/facebook/create-react-app).
 


### PR DESCRIPTION
To facilitate easy switchover from the landing page to the real website, we want to direct our DNS to Netlify and have them host the landing page until Friday.
This requires making our "production" build correspond to the `temp-landing` branch so this will be deployed on the apex domain.

We can continue to deploy `master` for easy reference, but it will need to be on a new subdomain, which should look like <https://master--kind-tesla-a088c1.netlify.app/>

This PR adds the new URL to our README, as well as forcing a new build on `master` which should make that URL actually work.