### PR TITLE
use ref for Dalena's engines

### DIFF
--- a/src/work/DalenaTran/index.js
+++ b/src/work/DalenaTran/index.js
@@ -41,13 +41,13 @@ import Seo from "../../Components/Seo";
 import { Link } from "react-router-dom";
 
 export default function ({slug, name}) {
-  let engines = new Engines();
   const aitContainer = useRef(null);
+  const enginesRef = useRef(null);
 
   const rootNodes = [document.body, document.documentElement];
 
   function beginProject() {
-    engines.init();
+    enginesRef.current.init();
 
     aitContainer.current.className = "";
     var video = document.getElementById("AITVidElem");
@@ -61,7 +61,7 @@ export default function ({slug, name}) {
   }
 
   function stopProject() {
-    engines.halt();
+    enginesRef.current.halt();
 
     aitContainer.current.className = "AITHide";
     window.setTimeout(() => {
@@ -77,9 +77,10 @@ export default function ({slug, name}) {
   }
 
   useEffect(() => {
-    if (navigator.userAgent === "ReactSnap") {
-      return;
-    }
+    // if (navigator.userAgent === "ReactSnap") {
+    //   return;
+    // }
+    const engines = (enginesRef.current = new Engines());
     engines.setup(audioJson, voiceoversJson, "AITSub");
 
     document.getElementById("AITLocA").className = "hidden";

--- a/src/work/DalenaTran/js/engines-utils.js
+++ b/src/work/DalenaTran/js/engines-utils.js
@@ -207,6 +207,8 @@ Engines.prototype = {
   },
 
   voiceoverUpdate() {
+    // console.log(this.timeEngine, this.audioEngine);
+    
     if (!this.isHalted) {
       requestAnimationFrame(this.voiceoverUpdate.bind(this));
 


### PR DESCRIPTION
This was perplexing. But PR #116 basically breaks Dalena's engines. Everything seems to be functional but `engines` is set to null for some reason. This causes `Uncaught TypeError: Cannot read property 'halt' of null` when clicking on `Return to Project Info`

The solution was to switch from 
https://github.com/blerchin/dma-20-mfa-show/blob/d8d5e92fe68dd03d1d5aa7fce1438a2a3f8fea7e/src/work/DalenaTran/index.js#L44

to
https://github.com/blerchin/dma-20-mfa-show/blob/beb9cfe2cd196992fe545750008c6abaa4eefb30/src/work/DalenaTran/index.js#L45

and set the ref in setup as in
https://github.com/blerchin/dma-20-mfa-show/blob/beb9cfe2cd196992fe545750008c6abaa4eefb30/src/work/DalenaTran/index.js#L83